### PR TITLE
Add admin stats command and service grouping query

### DIFF
--- a/config.py
+++ b/config.py
@@ -3,3 +3,4 @@ import os
 
 load_dotenv()
 BOT_TOKEN = os.getenv("BOT_TOKEN")
+ADMIN_IDS = [int(x) for x in os.getenv("ADMIN_IDS", "").split() if x.isdigit()]

--- a/db/database.py
+++ b/db/database.py
@@ -73,3 +73,16 @@ def delete_user_appointment(user_id, service, date, time):
             WHERE user_id = ? AND service = ? AND date = ? AND time = ?
         """, (user_id, service, date, time))
         conn.commit()
+
+
+def get_service_counts(start_date=None, end_date=None):
+    with sqlite3.connect(DB_PATH) as conn:
+        cursor = conn.cursor()
+        query = "SELECT service, COUNT(*) FROM appointments"
+        params = []
+        if start_date and end_date:
+            query += " WHERE date BETWEEN ? AND ?"
+            params.extend([start_date, end_date])
+        query += " GROUP BY service"
+        cursor.execute(query, params)
+        return cursor.fetchall()

--- a/handlers/admin_handlers.py
+++ b/handlers/admin_handlers.py
@@ -1,0 +1,35 @@
+from aiogram import Router
+from aiogram.filters import Command
+from aiogram.types import Message
+from config import ADMIN_IDS
+from db.database import get_service_counts
+from services.services import services
+
+router = Router()
+
+@router.message(Command("stats"))
+async def stats(message: Message):
+    if message.from_user.id not in ADMIN_IDS:
+        return
+
+    parts = message.text.split()
+    start_date = end_date = None
+    if len(parts) == 3:
+        start_date, end_date = parts[1], parts[2]
+
+    counts = get_service_counts(start_date, end_date)
+    if not counts:
+        await message.answer("Записей не найдено.")
+        return
+
+    total_minutes = 0
+    lines = []
+    for service, count in counts:
+        lines.append(f"{service}: {count}")
+        total_minutes += count * services.get(service, 0)
+
+    header = "Общая статистика:" if not start_date else f"Статистика с {start_date} по {end_date}:"
+    text = "\n".join(lines)
+    hours = total_minutes / 60
+    text += f"\n\nВсего часов: {hours:.1f}"
+    await message.answer(f"{header}\n{text}")

--- a/main.py
+++ b/main.py
@@ -1,11 +1,12 @@
 # main.py
 import asyncio
 from bot import bot, dp
-from handlers import user_handlers
+from handlers import user_handlers, admin_handlers
 from db.database import init_db
 
 async def main():
     init_db()  # создаёт базу данных при запуске
+    dp.include_router(admin_handlers.router)
     dp.include_router(user_handlers.router)
     await dp.start_polling(bot)
 


### PR DESCRIPTION
## Summary
- group appointments by service with new database query
- add admin-only /stats command to show appointment counts and total hours
- wire admin handler and configuration into bot startup

## Testing
- `python -m py_compile db/database.py handlers/admin_handlers.py config.py main.py`


------
https://chatgpt.com/codex/tasks/task_e_6895f4c327488323855b4ff9315ee4f8