### PR TITLE
Add admin broadcast command

### DIFF
--- a/db/user_storage.py
+++ b/db/user_storage.py
@@ -1,0 +1,36 @@
+import sqlite3
+from typing import List
+
+USER_DB_PATH = "users.db"
+
+
+def init_user_db() -> None:
+    with sqlite3.connect(USER_DB_PATH) as conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS users (
+                user_id INTEGER PRIMARY KEY
+            )
+            """
+        )
+        conn.commit()
+
+
+def add_user(user_id: int) -> None:
+    with sqlite3.connect(USER_DB_PATH) as conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            "INSERT OR IGNORE INTO users (user_id) VALUES (?)",
+            (user_id,)
+        )
+        conn.commit()
+
+
+def get_all_users() -> List[int]:
+    with sqlite3.connect(USER_DB_PATH) as conn:
+        cursor = conn.cursor()
+        cursor.execute("SELECT user_id FROM users")
+        return [row[0] for row in cursor.fetchall()]
+
+init_user_db()

--- a/handlers/admin_handlers.py
+++ b/handlers/admin_handlers.py
@@ -2,6 +2,9 @@ from aiogram import Router
 from aiogram.filters import Command
 from aiogram.types import Message
 from config import ADMIN_IDS
+from bot import bot
+from db.user_storage import get_all_users
+import logging
 from db.database import get_service_counts
 from services.services import services
 
@@ -33,3 +36,21 @@ async def stats(message: Message):
     hours = total_minutes / 60
     text += f"\n\nВсего часов: {hours:.1f}"
     await message.answer(f"{header}\n{text}")
+
+@router.message(Command("broadcast"))
+async def broadcast(message: Message):
+    if message.from_user.id not in ADMIN_IDS:
+        return
+
+    parts = message.text.split(maxsplit=1)
+    if len(parts) < 2:
+        await message.answer("Использование: /broadcast <message>")
+        return
+    text = parts[1]
+    user_ids = get_all_users()
+    for user_id in user_ids:
+        try:
+            await bot.send_message(user_id, text)
+        except Exception as e:
+            logging.exception(f"Failed to send broadcast to {user_id}: {e}")
+    await message.answer("Рассылка завершена.")


### PR DESCRIPTION
## Summary
- add user storage for tracking user IDs
- add admin-only /broadcast command to message all users

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68999d89edfc8323b0b5fb23469e0e7b