### PR TITLE
Use Redis storage for bot state

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1,6 +1,8 @@
 from aiogram import Bot, Dispatcher
-from config import BOT_TOKEN
-from aiogram.fsm.storage.memory import MemoryStorage
+from aiogram.fsm.storage.redis import RedisStorage
+from config import BOT_TOKEN, REDIS_HOST, REDIS_PORT, REDIS_DB
 
 bot = Bot(token=BOT_TOKEN)
-dp = Dispatcher(storage=MemoryStorage())
+redis_url = f"redis://{REDIS_HOST}:{REDIS_PORT}/{REDIS_DB}"
+storage = RedisStorage.from_url(redis_url)
+dp = Dispatcher(storage=storage)

--- a/config.py
+++ b/config.py
@@ -4,3 +4,6 @@ import os
 load_dotenv()
 BOT_TOKEN = os.getenv("BOT_TOKEN")
 ADMIN_IDS = [int(x) for x in os.getenv("ADMIN_IDS", "").split() if x.isdigit()]
+REDIS_HOST = os.getenv("REDIS_HOST", "localhost")
+REDIS_PORT = int(os.getenv("REDIS_PORT", "6379"))
+REDIS_DB = int(os.getenv("REDIS_DB", "0"))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 aiogram[fast]
 python-dotenv
+redis


### PR DESCRIPTION
## Summary
- add Redis connection settings to config
- switch bot to Redis storage and build connection URL from env vars
- include redis in requirements for persistent FSM storage

## Testing
- `python -m py_compile bot.py config.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68999d8df32c83239c77f5a72f87c3e8