### PR TITLE
Add admin panel handler, keyboard, and states

### DIFF
--- a/handlers/admin_handlers.py
+++ b/handlers/admin_handlers.py
@@ -7,8 +7,16 @@ from db.user_storage import get_all_users
 import logging
 from db.database import get_service_counts
 from services.services import services
+from keyboards.admin_menu import admin_menu
+from states.admin import AdminStates
 
 router = Router()
+
+@router.message(Command("admin"))
+async def admin_panel(message: Message):
+    if message.from_user.id not in ADMIN_IDS:
+        return
+    await message.answer("Админ‑панель:", reply_markup=admin_menu())
 
 @router.message(Command("stats"))
 async def stats(message: Message):

--- a/keyboards/admin_menu.py
+++ b/keyboards/admin_menu.py
@@ -1,0 +1,14 @@
+from aiogram.types import ReplyKeyboardMarkup, KeyboardButton
+
+
+def admin_menu():
+    return ReplyKeyboardMarkup(
+        keyboard=[
+            [KeyboardButton(text="📊 Статистика")],
+            [KeyboardButton(text="📣 Рассылка")],
+            [KeyboardButton(text="✍️ Записи")],
+            [KeyboardButton(text="🏖 Отпуск")],
+            [KeyboardButton(text="⬅️ Назад")],
+        ],
+        resize_keyboard=True,
+    )

--- a/states/admin.py
+++ b/states/admin.py
@@ -1,0 +1,8 @@
+from aiogram.fsm.state import StatesGroup, State
+
+
+class AdminStates(StatesGroup):
+    broadcast_message = State()
+    view_records = State()
+    vacation_start = State()
+    vacation_end = State()


### PR DESCRIPTION
## Summary
- add admin panel reply keyboard with statistics, broadcast, records, vacation, and back buttons
- define `AdminStates` for admin workflows
- implement `/admin` command handler that shows the admin panel

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6899aab710408323a6c0e385b8bdd69d