### PR TITLE
Add interactive admin stats handler

### DIFF
--- a/states/admin.py
+++ b/states/admin.py
@@ -1,0 +1,5 @@
+from aiogram.fsm.state import StatesGroup, State
+
+
+class AdminStates(StatesGroup):
+    stats_range = State()


### PR DESCRIPTION
## Summary
- allow admins to request statistics via "📊 Статистика" button with optional date range input
- refactor stats logic into reusable `build_stats_text`
- add AdminStates FSM for stats date range

## Testing
- `python -m py_compile handlers/admin_handlers.py states/admin.py`


------
https://chatgpt.com/codex/tasks/task_e_6899b3a143d883239b4627a605c38302