### PR TITLE
Add admin broadcast via FSM

### DIFF
--- a/handlers/admin_handlers.py
+++ b/handlers/admin_handlers.py
@@ -1,12 +1,15 @@
-from aiogram import Router
+from aiogram import Router, F
 from aiogram.filters import Command
 from aiogram.types import Message
+from aiogram.fsm.context import FSMContext
 from config import ADMIN_IDS
 from bot import bot
 from db.user_storage import get_all_users
 import logging
 from db.database import get_service_counts
 from services.services import services
+from states.admin import AdminStates
+from keyboards.menu import admin_menu
 
 router = Router()
 
@@ -37,6 +40,15 @@ async def stats(message: Message):
     text += f"\n\nВсего часов: {hours:.1f}"
     await message.answer(f"{header}\n{text}")
 
+
+@router.message(F.text == "📣 Рассылка")
+async def start_broadcast(message: Message, state: FSMContext):
+    if message.from_user.id not in ADMIN_IDS:
+        return
+    await state.set_state(AdminStates.broadcast_message)
+    await message.answer("Введите текст рассылки:")
+
+
 @router.message(Command("broadcast"))
 async def broadcast(message: Message):
     if message.from_user.id not in ADMIN_IDS:
@@ -54,3 +66,16 @@ async def broadcast(message: Message):
         except Exception as e:
             logging.exception(f"Failed to send broadcast to {user_id}: {e}")
     await message.answer("Рассылка завершена.")
+
+
+@router.message(AdminStates.broadcast_message)
+async def process_broadcast(message: Message, state: FSMContext):
+    text = message.text
+    user_ids = get_all_users()
+    for user_id in user_ids:
+        try:
+            await bot.send_message(user_id, text)
+        except Exception as e:
+            logging.exception(f"Failed to send broadcast to {user_id}: {e}")
+    await message.answer("Рассылка завершена.", reply_markup=admin_menu())
+    await state.clear()

--- a/keyboards/menu.py
+++ b/keyboards/menu.py
@@ -9,3 +9,12 @@ def main_menu():
         ],
         resize_keyboard=True
     )
+
+
+def admin_menu():
+    return ReplyKeyboardMarkup(
+        keyboard=[
+            [KeyboardButton(text="📣 Рассылка")]
+        ],
+        resize_keyboard=True
+    )

--- a/states/admin.py
+++ b/states/admin.py
@@ -1,0 +1,5 @@
+from aiogram.fsm.state import StatesGroup, State
+
+
+class AdminStates(StatesGroup):
+    broadcast_message = State()


### PR DESCRIPTION
## Summary
- Add admin_menu keyboard with broadcast option
- Implement broadcast flow using FSM and AdminStates
- Introduce AdminStates for broadcast message handling

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6899b3a1c39483238d7ccd65bab90879