### PR TITLE
Add admin appointment management

### DIFF
--- a/db/database.py
+++ b/db/database.py
@@ -120,3 +120,38 @@ async def get_service_counts(start_date=None, end_date=None):
         query += " GROUP BY service"
         cursor = await conn.execute(query, params)
         return await cursor.fetchall()
+
+
+async def get_all_appointments():
+    async with aiosqlite.connect(DB_PATH) as conn:
+        cursor = await conn.execute(
+            """
+            SELECT id, user_id, username, service, date, time
+            FROM appointments
+            ORDER BY date, time
+            """
+        )
+        return await cursor.fetchall()
+
+
+async def update_appointment(appointment_id, service=None, date=None, time=None):
+    fields = []
+    params = []
+    if service is not None:
+        fields.append("service = ?")
+        params.append(service)
+    if date is not None:
+        fields.append("date = ?")
+        params.append(date)
+    if time is not None:
+        fields.append("time = ?")
+        params.append(time)
+    if not fields:
+        return
+    params.append(appointment_id)
+    async with aiosqlite.connect(DB_PATH) as conn:
+        await conn.execute(
+            f"UPDATE appointments SET {', '.join(fields)} WHERE id = ?",
+            params,
+        )
+        await conn.commit()

--- a/handlers/admin_handlers.py
+++ b/handlers/admin_handlers.py
@@ -1,12 +1,25 @@
-from aiogram import Router
+from aiogram import Router, F
 from aiogram.filters import Command
 from aiogram.types import Message
+from aiogram.fsm.context import FSMContext
 from config import ADMIN_IDS
 from bot import bot
 from db.user_storage import get_all_users
 import logging
-from db.database import get_service_counts
+from db.database import (
+    get_service_counts,
+    get_all_appointments,
+    update_appointment,
+    delete_user_appointment,
+)
 from services.services import services
+from keyboards.admin import (
+    appointments_keyboard,
+    edit_options_keyboard,
+    confirm_keyboard,
+)
+from states.admin import AdminStates
+from datetime import datetime
 
 router = Router()
 
@@ -54,3 +67,121 @@ async def broadcast(message: Message):
         except Exception as e:
             logging.exception(f"Failed to send broadcast to {user_id}: {e}")
     await message.answer("Рассылка завершена.")
+
+
+@router.message(F.text == "✍️ Записи")
+async def show_appointments(message: Message, state: FSMContext):
+    if message.from_user.id not in ADMIN_IDS:
+        return
+    appointments = await get_all_appointments()
+    if not appointments:
+        await message.answer("Записей нет.")
+        return
+    await state.update_data(appointments=appointments)
+    await message.answer(
+        "Выберите запись:", reply_markup=appointments_keyboard(appointments)
+    )
+    await state.set_state(AdminStates.choosing_record)
+
+
+@router.message(AdminStates.choosing_record)
+async def choose_record(message: Message, state: FSMContext):
+    if message.text == "⬅️ Назад":
+        await state.clear()
+        return
+    data = await state.get_data()
+    appointments = {rec[0]: rec for rec in data.get("appointments", [])}
+    try:
+        rec_id = int(message.text.split(".")[0])
+    except ValueError:
+        await message.answer("Пожалуйста, выберите запись из списка.")
+        return
+    if rec_id not in appointments:
+        await message.answer("Пожалуйста, выберите запись из списка.")
+        return
+    record = appointments[rec_id]
+    await state.update_data(selected_record=record)
+    text = f"{record[4]} {record[5]} — {record[3]} ({record[2]})"
+    await message.answer(text, reply_markup=edit_options_keyboard())
+    await state.set_state(AdminStates.edit_record)
+
+
+@router.message(AdminStates.edit_record)
+async def edit_record(message: Message, state: FSMContext):
+    data = await state.get_data()
+    if message.text == "⬅️ Назад":
+        appointments = data.get("appointments", [])
+        await message.answer(
+            "Выберите запись:", reply_markup=appointments_keyboard(appointments)
+        )
+        await state.set_state(AdminStates.choosing_record)
+        return
+    record = data.get("selected_record")
+    if message.text == "🗑️ Удалить":
+        await delete_user_appointment(record[1], record[3], record[4], record[5])
+        appointments = await get_all_appointments()
+        if appointments:
+            await state.update_data(appointments=appointments)
+            await message.answer(
+                "Запись удалена. Выберите запись:",
+                reply_markup=appointments_keyboard(appointments),
+            )
+            await state.set_state(AdminStates.choosing_record)
+        else:
+            await state.clear()
+            await message.answer("Записей больше нет.")
+        return
+    if message.text == "✏️ Изменить":
+        await message.answer("Введите новую дату и время (YYYY-MM-DD HH:MM):")
+        await state.set_state(AdminStates.waiting_new_datetime)
+        return
+    await message.answer("Пожалуйста, выберите действие из меню.")
+
+
+@router.message(AdminStates.waiting_new_datetime)
+async def wait_new_datetime(message: Message, state: FSMContext):
+    if message.text == "⬅️ Назад":
+        await message.answer("Что сделать?", reply_markup=edit_options_keyboard())
+        await state.set_state(AdminStates.edit_record)
+        return
+    try:
+        new_date, new_time = message.text.split()
+        datetime.strptime(new_date, "%Y-%m-%d")
+        datetime.strptime(new_time, "%H:%M")
+    except Exception:
+        await message.answer(
+            "Неверный формат. Введите в формате YYYY-MM-DD HH:MM"
+        )
+        return
+    await state.update_data(new_date=new_date, new_time=new_time)
+    await message.answer(
+        f"Изменить на {new_date} {new_time}?", reply_markup=confirm_keyboard()
+    )
+    await state.set_state(AdminStates.confirm_update)
+
+
+@router.message(AdminStates.confirm_update)
+async def confirm_update_handler(message: Message, state: FSMContext):
+    data = await state.get_data()
+    if message.text == "✅ Подтвердить":
+        record = data.get("selected_record")
+        await update_appointment(
+            record[0], date=data["new_date"], time=data["new_time"]
+        )
+        appointments = await get_all_appointments()
+        if appointments:
+            await state.update_data(appointments=appointments)
+            await message.answer(
+                "Запись обновлена. Выберите запись:",
+                reply_markup=appointments_keyboard(appointments),
+            )
+            await state.set_state(AdminStates.choosing_record)
+        else:
+            await state.clear()
+            await message.answer("Записей нет.")
+        return
+    if message.text == "⬅️ Отмена":
+        await message.answer("Изменение отменено.", reply_markup=edit_options_keyboard())
+        await state.set_state(AdminStates.edit_record)
+        return
+    await message.answer("Пожалуйста, выберите действие из меню.")

--- a/keyboards/admin.py
+++ b/keyboards/admin.py
@@ -1,0 +1,29 @@
+from aiogram.types import ReplyKeyboardMarkup, KeyboardButton
+
+
+def appointments_keyboard(appointments):
+    keyboard = [
+        [KeyboardButton(text=f"{record[0]}. {record[4]} {record[5]} — {record[3]} ({record[2]})")]  # id, date, time, service, username
+        for record in appointments
+    ]
+    keyboard.append([KeyboardButton(text="⬅️ Назад")])
+    return ReplyKeyboardMarkup(keyboard=keyboard, resize_keyboard=True)
+
+
+def edit_options_keyboard():
+    return ReplyKeyboardMarkup(
+        keyboard=[
+            [KeyboardButton(text="✏️ Изменить"), KeyboardButton(text="🗑️ Удалить")],
+            [KeyboardButton(text="⬅️ Назад")],
+        ],
+        resize_keyboard=True,
+    )
+
+
+def confirm_keyboard():
+    return ReplyKeyboardMarkup(
+        keyboard=[
+            [KeyboardButton(text="✅ Подтвердить"), KeyboardButton(text="⬅️ Отмена")],
+        ],
+        resize_keyboard=True,
+    )

--- a/states/admin.py
+++ b/states/admin.py
@@ -1,0 +1,7 @@
+from aiogram.fsm.state import StatesGroup, State
+
+class AdminStates(StatesGroup):
+    choosing_record = State()
+    edit_record = State()
+    waiting_new_datetime = State()
+    confirm_update = State()


### PR DESCRIPTION
## Summary
- add database functions to fetch and update appointments
- introduce admin states and keyboards for record management
- allow admins to list, edit, and delete appointments via new handlers

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6899b3a25d9c8323b0b5543cdfcf07ca