### PR TITLE
Add FSM-based admin statistics handler

### DIFF
--- a/states/admin.py
+++ b/states/admin.py
@@ -6,3 +6,5 @@ class AdminStates(StatesGroup):
     view_records = State()
     vacation_start = State()
     vacation_end = State()
+    stats_start = State()
+    stats_end = State()


### PR DESCRIPTION
## Summary
- add AdminStates for statistics start and end dates
- implement handler for "📊 Статистика" that prompts for period and returns service counts

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6899b7c045448323afb9e34400bc1105