### PR TITLE
feat: add admin back navigation

### DIFF
--- a/handlers/admin_handlers.py
+++ b/handlers/admin_handlers.py
@@ -10,6 +10,7 @@ import logging
 from db.database import get_service_counts, add_vacation_date
 from services.services import services
 from keyboards.admin_menu import admin_menu
+from keyboards.menu import main_menu
 from states.admin import AdminStates
 
 router = Router()
@@ -19,6 +20,14 @@ async def admin_panel(message: Message):
     if message.from_user.id not in ADMIN_IDS:
         return
     await message.answer("Админ‑панель:", reply_markup=admin_menu())
+
+
+@router.message(F.text == "⬅️ Назад")
+async def admin_back(message: Message, state: FSMContext):
+    if message.from_user.id not in ADMIN_IDS:
+        return
+    await state.clear()
+    await message.answer("Главное меню", reply_markup=main_menu())
 
 @router.message(Command("stats"))
 async def stats(message: Message):


### PR DESCRIPTION
## Summary
- allow admins to exit the admin panel via "⬅️ Назад" button

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_6899be4556248323a0027f4669067107