### PR TITLE
Handle missing Redis by falling back to memory storage

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1,8 +1,18 @@
 from aiogram import Bot, Dispatcher
 from aiogram.fsm.storage.redis import RedisStorage
+from aiogram.fsm.storage.memory import MemoryStorage
 from config import BOT_TOKEN, REDIS_HOST, REDIS_PORT, REDIS_DB
+import redis
+import logging
 
 bot = Bot(token=BOT_TOKEN)
 redis_url = f"redis://{REDIS_HOST}:{REDIS_PORT}/{REDIS_DB}"
-storage = RedisStorage.from_url(redis_url)
+
+try:
+    redis.Redis(host=REDIS_HOST, port=REDIS_PORT, db=REDIS_DB).ping()
+    storage = RedisStorage.from_url(redis_url)
+except redis.exceptions.ConnectionError:
+    logging.warning("Redis unavailable, using in-memory storage")
+    storage = MemoryStorage()
+
 dp = Dispatcher(storage=storage)


### PR DESCRIPTION
## Summary
- try to ping Redis and use it if available
- fall back to aiogram MemoryStorage when Redis is unreachable

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python - <<'PY'
import bot
print(type(bot.dp.storage))
PY`


------
https://chatgpt.com/codex/tasks/task_e_689a0038cc80832397c37e6be306f3df